### PR TITLE
Derive macro minijinja

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
-        crate: [anvil, anvil-askama, anvil-liquid, anvil-minijinja, anvil-tera]
+        crate: [anvil, anvil-askama, anvil-liquid, anvil-minijinja, anvil-tera, anvil-minijinja-derive]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -467,6 +468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "globset"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +575,12 @@ dependencies = [
  "ignore",
  "walkdir",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -616,6 +635,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1054,6 +1083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1186,15 @@ dependencies = [
  "serde_json",
  "slug",
  "unic-segment",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1193,6 +1246,62 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
+
+[[package]]
+name = "trybuild"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "anvil-minijinja-derive"
+version = "0.1.0"
+dependencies = [
+ "anvil-minijinja 0.1.1",
+ "minijinja",
+ "minijinja-embed",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
 name = "anvil-tera"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
   "anvil", 
   "anvil-askama", 
   "anvil-liquid", 
-  "anvil-minijinja", "anvil-minijinja-derive", 
+  "anvil-minijinja", 
+  "anvil-minijinja-derive", 
   "anvil-tera", 
   "examples"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
   "anvil", 
   "anvil-askama", 
   "anvil-liquid", 
-  "anvil-minijinja", 
+  "anvil-minijinja", "anvil-minijinja-derive", 
   "anvil-tera", 
   "examples"
 ]

--- a/anvil-minijinja-derive/Cargo.toml
+++ b/anvil-minijinja-derive/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "anvil-minijinja-derive"
+version = "0.1.0"
+edition = "2021"
+homepage = "https://github.com/anvil-rs/anvil"
+description = "Derive macro for anvil-minijinja"
+license = "MIT"
+repository = "https://github.com/anvil-rs/anvil"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+anvil-minijinja = { path = "../anvil-minijinja" }
+serde = { version = "1.0", features = ["derive"] }
+minijinja = "2.8.0"
+minijinja-embed = "2.8.0"
+
+[build-dependencies]
+minijinja-embed = "2.8.0"

--- a/anvil-minijinja-derive/Cargo.toml
+++ b/anvil-minijinja-derive/Cargo.toml
@@ -20,6 +20,7 @@ anvil-minijinja = { path = "../anvil-minijinja" }
 serde = { version = "1.0", features = ["derive"] }
 minijinja = "2.8.0"
 minijinja-embed = "2.8.0"
+trybuild = "1.0.104"
 
 [build-dependencies]
 minijinja-embed = "2.8.0"

--- a/anvil-minijinja-derive/build.rs
+++ b/anvil-minijinja-derive/build.rs
@@ -1,4 +1,6 @@
 fn main() {
-    println!("cargo:rerun-if-changed=tests/templates");
-    minijinja_embed::embed_templates!("tests/templates/");
+    if cfg!(test) {
+        println!("cargo:rerun-if-changed=tests/templates");
+        minijinja_embed::embed_templates!("tests/templates/");
+    }
 }

--- a/anvil-minijinja-derive/build.rs
+++ b/anvil-minijinja-derive/build.rs
@@ -1,6 +1,4 @@
 fn main() {
-    if cfg!(test) {
-        println!("cargo:rerun-if-changed=tests/templates");
-        minijinja_embed::embed_templates!("tests/templates/");
-    }
+    println!("cargo:rerun-if-changed=tests/templates");
+    minijinja_embed::embed_templates!("tests/templates/");
 }

--- a/anvil-minijinja-derive/build.rs
+++ b/anvil-minijinja-derive/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=tests/templates");
+    minijinja_embed::embed_templates!("tests/templates/");
+}

--- a/anvil-minijinja-derive/src/lib.rs
+++ b/anvil-minijinja-derive/src/lib.rs
@@ -60,7 +60,7 @@ pub fn derive_template(input: TokenStream) -> TokenStream {
     // Generate the implementation
     let expanded = quote! {
         impl ::anvil_minijinja::Shrine for #name {
-            fn minijinja(&self, writer: &mut dyn ::std::io::Write) -> Result<(), ::minijinja::Error> {
+            fn minijinja(&self, writer: &mut dyn ::std::io::Write) -> ::std::result::Result<(), ::minijinja::Error> {
                 let mut env = ::minijinja::Environment::new();
                 ::minijinja_embed::load_templates!(&mut env);
                 let tmpl = env.get_template(#template_name)?;

--- a/anvil-minijinja-derive/src/lib.rs
+++ b/anvil-minijinja-derive/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Error, Lit, Expr, ExprLit};
+use syn::{parse_macro_input, DeriveInput, Error, Expr, ExprLit, Lit};
 
 /// A derive macro for implementing the `Shrine` trait from the `anvil-minijinja` crate.
 ///
@@ -28,12 +28,12 @@ use syn::{parse_macro_input, DeriveInput, Error, Lit, Expr, ExprLit};
 /// use anvil_minijinja::Shrine;
 /// use std::io::Write;
 /// use minijinja;
-/// 
+///
 /// #[derive(Serialize)]
 /// struct MyTemplate {
 ///     name: String,
 /// }
-/// 
+///
 /// impl Shrine for MyTemplate {
 ///     fn minijinja(&self, writer: &mut dyn Write) -> Result<(), minijinja::Error> {
 ///         let mut env = minijinja::Environment::new();
@@ -78,8 +78,12 @@ fn extract_template_name(input: &DeriveInput) -> Result<String, Error> {
     for attr in &input.attrs {
         if attr.path().is_ident("template") {
             let expr = attr.parse_args::<Expr>()?;
-            
-            if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = expr {
+
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Str(lit_str),
+                ..
+            }) = expr
+            {
                 return Ok(lit_str.value());
             } else {
                 let err_msg = "Expected template attribute to be in the form #[template(\"template_name.ext\")]";
@@ -87,7 +91,7 @@ fn extract_template_name(input: &DeriveInput) -> Result<String, Error> {
             }
         }
     }
-    
+
     Err(Error::new_spanned(
         input,
         "Missing #[template(\"template_name.ext\")] attribute",

--- a/anvil-minijinja-derive/src/lib.rs
+++ b/anvil-minijinja-derive/src/lib.rs
@@ -1,0 +1,95 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Error, Lit, Expr, ExprLit};
+
+/// A derive macro for implementing the `Shrine` trait from the `anvil-minijinja` crate.
+///
+/// # Example
+///
+/// ```no_run
+/// // These imports would be needed in a real application
+/// use serde::Serialize;
+/// use anvil_minijinja_derive::Template;
+/// use anvil_minijinja::Shrine;
+/// use std::io::Write;
+///
+/// #[derive(Serialize, Template)]
+/// #[template("my_template.txt")]
+/// struct MyTemplate {
+///     name: String,
+/// }
+/// ```
+///
+/// This expands to code equivalent to:
+///
+/// ```no_run
+/// // Note: This is pseudocode showing what the macro generates
+/// use serde::Serialize;
+/// use anvil_minijinja::Shrine;
+/// use std::io::Write;
+/// use minijinja;
+/// 
+/// #[derive(Serialize)]
+/// struct MyTemplate {
+///     name: String,
+/// }
+/// 
+/// impl Shrine for MyTemplate {
+///     fn minijinja(&self, writer: &mut dyn Write) -> Result<(), minijinja::Error> {
+///         let mut env = minijinja::Environment::new();
+///         minijinja_embed::load_templates!(&mut env);
+///         let tmpl = env.get_template("my_template.txt")?;
+///         tmpl.render_to_write(self, writer)?;
+///         Ok(())
+///     }
+/// }
+/// ```
+#[proc_macro_derive(Template, attributes(template))]
+pub fn derive_template(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Extract the name of the struct
+    let name = &input.ident;
+
+    // Find the template attribute
+    let template_name = match extract_template_name(&input) {
+        Ok(name) => name,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    // Generate the implementation
+    let expanded = quote! {
+        impl ::anvil_minijinja::Shrine for #name {
+            fn minijinja(&self, writer: &mut dyn ::std::io::Write) -> Result<(), ::minijinja::Error> {
+                let mut env = ::minijinja::Environment::new();
+                ::minijinja_embed::load_templates!(&mut env);
+                let tmpl = env.get_template(#template_name)?;
+                tmpl.render_to_write(self, writer)?;
+                Ok(())
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Extracts the template name from the attributes of a struct.
+fn extract_template_name(input: &DeriveInput) -> Result<String, Error> {
+    for attr in &input.attrs {
+        if attr.path().is_ident("template") {
+            let expr = attr.parse_args::<Expr>()?;
+            
+            if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), .. }) = expr {
+                return Ok(lit_str.value());
+            } else {
+                let err_msg = "Expected template attribute to be in the form #[template(\"template_name.ext\")]";
+                return Err(Error::new_spanned(attr, err_msg));
+            }
+        }
+    }
+    
+    Err(Error::new_spanned(
+        input,
+        "Missing #[template(\"template_name.ext\")] attribute",
+    ))
+}

--- a/anvil-minijinja-derive/tests/compile_fail/incorrect_format.rs
+++ b/anvil-minijinja-derive/tests/compile_fail/incorrect_format.rs
@@ -1,0 +1,15 @@
+// This file tests the error when a template has an incorrectly formatted template attribute
+// Expected error: "Expected template attribute to be in the form #[template(\"template_name.ext\")]"
+
+use anvil_minijinja_derive::Template;
+use serde::Serialize;
+
+#[derive(Serialize, Template)]
+#[template(123)]  // Using a number instead of a string literal
+struct IncorrectFormatTemplate {
+    value: String,
+}
+
+fn main() {
+    // This will never run, we're only testing the compile-time error
+}

--- a/anvil-minijinja-derive/tests/compile_fail/incorrect_format.stderr
+++ b/anvil-minijinja-derive/tests/compile_fail/incorrect_format.stderr
@@ -1,0 +1,5 @@
+error: Expected template attribute to be in the form #[template("template_name.ext")]
+ --> tests/compile_fail/incorrect_format.rs
+  |
+  | #[template(123)]  // Using a number instead of a string literal
+  | ^^^^^^^^^^^^^^^^

--- a/anvil-minijinja-derive/tests/compile_fail/missing_attribute.rs
+++ b/anvil-minijinja-derive/tests/compile_fail/missing_attribute.rs
@@ -1,0 +1,14 @@
+// This file tests the error when a template is missing the required template attribute
+// Expected error: "Missing #[template(\"template_name.ext\")] attribute"
+
+use anvil_minijinja_derive::Template;
+use serde::Serialize;
+
+#[derive(Serialize, Template)]  // Missing #[template("...")] attribute
+struct MissingAttributeTemplate {
+    value: String,
+}
+
+fn main() {
+    // This will never run, we're only testing the compile-time error
+}

--- a/anvil-minijinja-derive/tests/compile_fail/missing_attribute.stderr
+++ b/anvil-minijinja-derive/tests/compile_fail/missing_attribute.stderr
@@ -1,0 +1,7 @@
+error: Missing #[template("template_name.ext")] attribute
+ --> tests/compile_fail/missing_attribute.rs
+  |
+  | / struct MissingAttributeTemplate {
+  | |     value: String,
+  | | }
+  | |_^

--- a/anvil-minijinja-derive/tests/compile_tests.rs
+++ b/anvil-minijinja-derive/tests/compile_tests.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn compile_tests() {
     let t = trybuild::TestCases::new();
 

--- a/anvil-minijinja-derive/tests/compile_tests.rs
+++ b/anvil-minijinja-derive/tests/compile_tests.rs
@@ -1,0 +1,18 @@
+// This file runs the compile-fail tests using trybuild
+// It verifies that our derive macro properly handles error cases
+
+use std::path::PathBuf;
+
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+
+    // Path to our compile-fail tests
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("compile_fail");
+
+    // Add all error case tests in the compile_fail directory
+    t.compile_fail(dir.join("missing_attribute.rs"));
+    t.compile_fail(dir.join("incorrect_format.rs"));
+}

--- a/anvil-minijinja-derive/tests/template_derive_test.rs
+++ b/anvil-minijinja-derive/tests/template_derive_test.rs
@@ -9,7 +9,7 @@ struct TestTemplate {
     name: String,
 }
 
-// Test the template rendering
+// Write a basic test to verify the derive macro works correctly
 #[test]
 fn test_template_derive() {
     // Setup the test template
@@ -29,4 +29,35 @@ fn test_template_derive() {
         output.contains("Hello, John!"),
         "Template output doesn't match expected content"
     );
+}
+
+// The tests below verify error handling in the derive macro
+
+// Test compile error for missing template attribute
+// This will cause a compile error: "Missing #[template(\"template_name.ext\")] attribute"
+#[test]
+fn test_missing_template_attribute() {
+    // This test will only verify that the code compiles correctly
+    // The actual compile error will be tested during build time via a separate file
+
+    // Intentionally commented out to prevent actual compile errors:
+    // #[derive(Serialize, Template)]
+    // struct MissingAttributeTemplate {
+    //     value: String,
+    // }
+}
+
+// Test compile error for incorrect template attribute format
+// This will cause a compile error: "Expected template attribute to be in the form #[template(\"template_name.ext\")]"
+#[test]
+fn test_incorrect_template_format() {
+    // This test will only verify that the code compiles correctly
+    // The actual compile error will be tested during build time via a separate file
+
+    // Intentionally commented out to prevent actual compile errors:
+    // #[derive(Serialize, Template)]
+    // #[template(123)]  // Using a number instead of a string literal
+    // struct IncorrectFormatTemplate {
+    //     value: String,
+    // }
 }

--- a/anvil-minijinja-derive/tests/template_derive_test.rs
+++ b/anvil-minijinja-derive/tests/template_derive_test.rs
@@ -1,0 +1,28 @@
+
+use anvil_minijinja::Shrine;
+use anvil_minijinja_derive::Template;
+use serde::Serialize;
+
+// Create a test template struct with the Template derive macro
+#[derive(Serialize, Template)]
+#[template("test.txt")]
+struct TestTemplate {
+    name: String,
+}
+
+// Test the template rendering
+#[test]
+fn test_template_derive() {
+    // Setup the test template
+    let template = TestTemplate {
+        name: String::from("John"),
+    };
+    
+    // Render the template to a buffer
+    let mut buffer = Vec::new();
+    template.minijinja(&mut buffer).expect("Failed to render template");
+    
+    // Verify the output
+    let output = String::from_utf8(buffer).expect("Output was not valid UTF-8");
+    assert!(output.contains("Hello, John!"), "Template output doesn't match expected content");
+}

--- a/anvil-minijinja-derive/tests/template_derive_test.rs
+++ b/anvil-minijinja-derive/tests/template_derive_test.rs
@@ -1,4 +1,3 @@
-
 use anvil_minijinja::Shrine;
 use anvil_minijinja_derive::Template;
 use serde::Serialize;
@@ -17,12 +16,17 @@ fn test_template_derive() {
     let template = TestTemplate {
         name: String::from("John"),
     };
-    
+
     // Render the template to a buffer
     let mut buffer = Vec::new();
-    template.minijinja(&mut buffer).expect("Failed to render template");
-    
+    template
+        .minijinja(&mut buffer)
+        .expect("Failed to render template");
+
     // Verify the output
     let output = String::from_utf8(buffer).expect("Output was not valid UTF-8");
-    assert!(output.contains("Hello, John!"), "Template output doesn't match expected content");
+    assert!(
+        output.contains("Hello, John!"),
+        "Template output doesn't match expected content"
+    );
 }

--- a/anvil-minijinja-derive/tests/templates/test.txt
+++ b/anvil-minijinja-derive/tests/templates/test.txt
@@ -1,0 +1,1 @@
+Hello, {{ name }}!


### PR DESCRIPTION
Addresses #12

This pull request introduces a new crate, `anvil-minijinja-derive`, which provides a procedural macro for generating `Shrine` trait implementations for `anvil-minijinja`. The changes include adding the new crate to the project, implementing its functionality, and updating the project configuration to integrate it.

### Addition of `anvil-minijinja-derive` crate:

* **New crate definition**: Added `anvil-minijinja-derive` with metadata, dependencies, and build configuration. The crate defines itself as a procedural macro library with dependencies like `proc-macro2`, `quote`, and `syn` for macro generation.
* **Build script**: Introduced a `build.rs` file to embed templates for the procedural macro during build time.

### Implementation of `Template` derive macro:

* **Macro functionality**: Added a `Template` derive macro that generates `Shrine` trait implementations for structs. It processes a `#[template("template_name")]` attribute to specify the template file and generates code to render the template using `minijinja`.

### Testing and examples:

* **Unit test**: Created a test to validate the functionality of the `Template` derive macro by rendering a template with a test struct.
* **Test template**: Added a sample template file, `test.txt`, for use in the unit test.

### Integration with the project:

* **Project configuration**: Updated `Cargo.toml` to include `anvil-minijinja-derive` as a workspace member and added it to the linting matrix in the CI workflow. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L7-R7) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L85-R85)